### PR TITLE
Updating to Azure Boards category

### DIFF
--- a/src/vsarVSTS-Roll-up-board/vss-extension.json
+++ b/src/vsarVSTS-Roll-up-board/vss-extension.json
@@ -80,7 +80,7 @@
     }
   ],
   "categories": [
-    "Plan and track"
+    "Azure Boards"
   ],
   "contributions": [
     {


### PR DESCRIPTION
The track and plan category does not exist anymore, our extension moved to Azure Boards, following the same line of thought.

Thank you for your pull request!
By completing this pull request, you agree to the [Contributing License Agreement](https://github.com/ALM-Rangers/Roll-Up-Board-Widget-Extension/blob/master/.github/CLA.md).

Fixes # .

Changes proposed in this pull request:  
- 
- 
- 

@ALM-Rangers/Roll-Up-Board-Widget-Extension
